### PR TITLE
[#28] feat: Enable git auto setup remote branch

### DIFF
--- a/modules/common/shell/git.nix
+++ b/modules/common/shell/git.nix
@@ -19,6 +19,9 @@ in
         extraConfig = {
           core.editor = "nvim";
 
+          # Auto setup remote branch if not exists
+          push = { autoSetupRemote = true; };
+
           gpg = {
             format = "ssh";
           };


### PR DESCRIPTION
Problem:
Git returns error if remote branch doesn't exists. By default you need to setup remote origin for a local git branch.

Solution:
Added config to automatically setup remote branch.